### PR TITLE
Fix qtcutil

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -135,8 +135,6 @@ extern int nr_qtcsent;
 extern t_qtcreclist qtcreclist;		// the QTC list which received
 
 extern int qtcdirection;
-extern struct t_qtc_store_obj *qtc_temp_obj;
-extern struct t_qtc_store_obj *qtc_empty_obj;
 extern t_pfxnummulti pfxnummulti[MAXPFXNUMMULT];
 extern int pfxnummultinr;
 extern int continentlist_only;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -134,7 +134,6 @@ extern t_qtclist qtclist;		// the QTC list to send
 extern int nr_qtcsent;
 extern t_qtcreclist qtcreclist;		// the QTC list which received
 
-extern GHashTable* qtc_store;
 extern int qtcdirection;
 extern struct t_qtc_store_obj *qtc_temp_obj;
 extern struct t_qtc_store_obj *qtc_empty_obj;

--- a/src/main.c
+++ b/src/main.c
@@ -339,7 +339,6 @@ t_qtclist qtclist;
 int nr_qtcsent = 0;
 t_qtcreclist qtcreclist;
 struct t_qtc_store_obj *qtc_temp_obj;
-struct t_qtc_store_obj *qtc_empty_obj;
 int qtcdirection = 0;
 //char qtc_ry_lines[12][50] = {"", "", "", "", "", "", "", "", "", "", "", ""};
 //int qtc_ry_lines_attr[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};

--- a/src/main.c
+++ b/src/main.c
@@ -338,7 +338,6 @@ int next_qtc_qso;
 t_qtclist qtclist;
 int nr_qtcsent = 0;
 t_qtcreclist qtcreclist;
-GHashTable* qtc_store = NULL;
 struct t_qtc_store_obj *qtc_temp_obj;
 struct t_qtc_store_obj *qtc_empty_obj;
 int qtcdirection = 0;

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -27,7 +27,7 @@
 #include <glib.h>
 #include "tlf.h"
 
-extern GHashTable* qtc_store; // = NULL;
+GHashTable* qtc_store = NULL;
 extern int qtcdirection;
 extern struct t_qtc_store_obj *qtc_empty_obj;
 

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -27,19 +27,22 @@
 #include <glib.h>
 #include "tlf.h"
 
-GHashTable* qtc_store = NULL;
+GHashTable* qtc_store = NULL; 	/* stores number of QTC's per callsign */
+struct t_qtc_store_obj *qtc_empty_obj = NULL;
+
 extern int qtcdirection;
 extern struct t_qtc_store_obj *qtc_empty_obj;
 
 void qtc_init() {
-        if (qtc_store != NULL) {
+    if (qtc_store != NULL) {
 	g_hash_table_destroy(qtc_store);
     }
+    qtc_store = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
     if (qtc_empty_obj != NULL) {
 	g_free(qtc_empty_obj);
     }
-    qtc_store = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-    qtc_empty_obj = g_malloc0(sizeof (struct t_qtc_store_obj));
+    qtc_empty_obj = g_malloc(sizeof (struct t_qtc_store_obj));
     qtc_empty_obj->total = 0;
     qtc_empty_obj->received = 0;
     qtc_empty_obj->sent = 0;

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -22,9 +22,8 @@
 	 *--------------------------------------------------------------*/
 
 #include "qtcutil.h"
-#include <stdio.h>
-#include <stdlib.h>
 #include <glib.h>
+#include "string.h"
 #include "tlf.h"
 
 GHashTable* qtc_store = NULL; 	/* stores number of QTC's per callsign */
@@ -101,7 +100,7 @@ struct t_qtc_store_obj * qtc_get(char callsign[15]) {
 
 }
 
-int parse_qtcline(char * logline, char callsign[15], int direction) {
+void parse_qtcline(char * logline, char callsign[15], int direction) {
 
     int i = 0;
 
@@ -115,7 +114,5 @@ int parse_qtcline(char * logline, char callsign[15], int direction) {
 	i++;
     }
     callsign[i] = '\0';
-
-    return 0;
 }
 

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -31,6 +31,20 @@ extern GHashTable* qtc_store; // = NULL;
 extern int qtcdirection;
 extern struct t_qtc_store_obj *qtc_empty_obj;
 
+void qtc_init() {
+        if (qtc_store != NULL) {
+	g_hash_table_destroy(qtc_store);
+    }
+    if (qtc_empty_obj != NULL) {
+	g_free(qtc_empty_obj);
+    }
+    qtc_store = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+    qtc_empty_obj = g_malloc0(sizeof (struct t_qtc_store_obj));
+    qtc_empty_obj->total = 0;
+    qtc_empty_obj->received = 0;
+    qtc_empty_obj->sent = 0;
+}
+
 void qtc_inc(char callsign[15], int direction) {
     struct t_qtc_store_obj *qtc_obj;
 

--- a/src/qtcutil.h
+++ b/src/qtcutil.h
@@ -20,6 +20,12 @@
 #ifndef QTCUTIL_H
 #define QTCUTIL_H
 
+struct t_qtc_store_obj {
+  int total;
+  int received;
+  int sent;
+};
+
 void qtc_init();
 void qtc_inc(char callsign[15], int direction);
 void qtc_dec(char callsign[15], int direction);

--- a/src/qtcutil.h
+++ b/src/qtcutil.h
@@ -20,6 +20,7 @@
 #ifndef QTCUTIL_H
 #define QTCUTIL_H
 
+void qtc_init();
 void qtc_inc(char callsign[15], int direction);
 void qtc_dec(char callsign[15], int direction);
 struct t_qtc_store_obj * qtc_get(char callsign[15]);

--- a/src/qtcutil.h
+++ b/src/qtcutil.h
@@ -31,6 +31,6 @@ void qtc_inc(char callsign[15], int direction);
 void qtc_dec(char callsign[15], int direction);
 struct t_qtc_store_obj * qtc_get(char callsign[15]);
 
-int parse_qtcline(char * line, char callsign[15], int direction);
+void parse_qtcline(char * line, char callsign[15], int direction);
 
 #endif /* end of include guard: QTCUTIL_H */

--- a/src/readqtccalls.c
+++ b/src/readqtccalls.c
@@ -59,7 +59,7 @@ int readqtccalls()
     if (qtc_empty_obj != NULL) {
 	g_free(qtc_empty_obj);
     }
-    qtc_store = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    qtc_store = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
     qtc_empty_obj = g_malloc0(sizeof (struct t_qtc_store_obj));
     qtc_empty_obj->total = 0;
     qtc_empty_obj->received = 0;

--- a/src/readqtccalls.c
+++ b/src/readqtccalls.c
@@ -36,8 +36,6 @@
 #include <ctype.h>
 
 extern int qtcdirection;
-extern GHashTable* qtc_store;
-extern struct t_qtc_store_obj *qtc_empty_obj;
 extern int nr_qsosflags_for_qtc;
 extern int nr_qsos;
 
@@ -53,17 +51,8 @@ int readqtccalls()
 
     clear();
 
-    if (qtc_store != NULL) {
-	g_hash_table_destroy(qtc_store);
-    }
-    if (qtc_empty_obj != NULL) {
-	g_free(qtc_empty_obj);
-    }
-    qtc_store = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-    qtc_empty_obj = g_malloc0(sizeof (struct t_qtc_store_obj));
-    qtc_empty_obj->total = 0;
-    qtc_empty_obj->received = 0;
-    qtc_empty_obj->sent = 0;
+    qtc_init();
+
     nr_qsosflags_for_qtc = nr_qsos;
 
     if (qtcdirection & 2) {

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -221,12 +221,6 @@ typedef struct {
 #define RECV 1		// QTC RECV direction
 #define SEND 2		// QTC SEND direction
 
-struct t_qtc_store_obj {
-  int total;
-  int received;
-  int sent;
-};
-
 void refreshp();
 
 #endif /* TLF_H */


### PR DESCRIPTION
Please pull in the following fixes and changes to the qtutil functions:

- fix memory leaks in constructor of the has table
- initialize qtc_empty_obj to NULL
- introduce a new function qtc_init() and use it in readqtccalls.c
- make qtc_empty_obj and qtc_store privat in qtutils.c. No one outside that module needs to know how the information is handled inside.
- change prototype of parse_qtcline()
- move declaration of t_qtc_store_obj to qtcutils.h

